### PR TITLE
fix: bump version in `Info.plist` to 2.0.1 to match `version.json`

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -13,7 +13,7 @@
     <key>CFBundleVersion</key>
     <string>2</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.0.0</string>
+    <string>2.0.1</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleIconFile</key>


### PR DESCRIPTION
Otherwise the built app thinks it's on `2.0.0` and displays an update suggestion alert.

Encountered the issue after building and running the app  from source. 
Fixed and tested by re-building –> "new version available" dialog stopped appearing 👍 

I wonder if that affects everyone who installs from brew/dmg – maybe they all get the update suggestion as well, but after updating it doesn't disappear? 🤔 
You might wanna release 2.0.2 to fix this...