### PR TITLE
Fix: Cmd+A doesn't reset key buffer, causing text loss on full-text conversion

### DIFF
--- a/Sources/RuSwitcher/KeyboardMonitor.swift
+++ b/Sources/RuSwitcher/KeyboardMonitor.swift
@@ -298,9 +298,12 @@ final class KeyboardMonitor: @unchecked Sendable {
             return
         }
 
-        // Буквы считаем только без Cmd/Ctrl/Alt
+        // (Cmd+A, Cmd+C, Cmd+X и т.п.) могло изменить выделение — сбрасываем наш буфер.
         let modifiers = flags.intersection([.maskCommand, .maskControl, .maskAlternate])
-        if !modifiers.isEmpty { return }
+        if !modifiers.isEmpty {
+            fullReset()
+            return
+        }
 
         if KeyMapping.keycodeToEN[keyCode] != nil {
             currentWordKeys.append(TypedKey(keyCode: keyCode, shift: flags.contains(.maskShift), caps: flags.contains(.maskAlphaShift)))


### PR DESCRIPTION
**Bug:** When selecting all text with Cmd+A before converting, the app deletes the entire text instead of converting it, leaving only the last typed word converted.

**Cause:** `handleKeyDown` returns early on any Cmd/Ctrl/Alt modifier without resetting the internal keystroke buffer (`currentWordKeys`). If the user selects text via a keyboard shortcut (not mouse), the buffer stays stale from before the selection. When the trigger key is pressed, the buffer-based conversion engine calls backspace() based on the stale buffer length — but since a selection is now active, the first backspace deletes the entire selection, and only the stale buffered word gets inserted back.

**Fix:** Reset the buffer (`fullReset()`) whenever a Cmd/Ctrl/Alt modifier is detected, since any such shortcut could have changed the selection state.

Tested locally — Cmd+A + convert now correctly converts the whole selection instead of collapsing it to one word.