### PR TITLE
Плавность: устранены затыки main-потока, голодившие event tap

### DIFF
--- a/macos/Sources/RuSwitcher/AppDelegate.swift
+++ b/macos/Sources/RuSwitcher/AppDelegate.swift
@@ -34,6 +34,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         updateCheckTimer = Timer.scheduledTimer(withTimeInterval: 6 * 3600, repeats: true) { _ in
             Task { @MainActor in UpdateChecker.checkPeriodic() }
         }
+        // Прогрев NSSpellChecker: первый чек поднимает XPC AppleSpell (сотни мс на main) —
+        // прогреваем в тихую паузу после старта, а не на первом пробеле пользователя.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            Task { @MainActor in Dict.warmUp() }
+        }
     }
 
     private func setupSettingsCallbacks() {

--- a/macos/Sources/RuSwitcher/AutoSwitch.swift
+++ b/macos/Sources/RuSwitcher/AutoSwitch.swift
@@ -6,10 +6,28 @@ import IOKit
 /// без сети и без бандла данных. ~0.1мс на проверку, 40+ языков.
 enum Dict {
     @MainActor private static let checker = NSSpellChecker.shared
+    /// Кэш списка словарей: availableLanguages ходит в AppleSpell — не дёргаем на каждое слово.
+    @MainActor private static var cachedLanguages: [String]?
 
     @MainActor static func isAvailable(_ lang: String) -> Bool {
         let two = String(lang.prefix(2))
-        return checker.availableLanguages.contains { String($0.prefix(2)) == two }
+        return languages().contains { String($0.prefix(2)) == two }
+    }
+
+    @MainActor private static func languages() -> [String] {
+        if let cached = cachedLanguages { return cached }
+        let langs = checker.availableLanguages
+        cachedLanguages = langs
+        return langs
+    }
+
+    /// Прогрев: первое обращение к NSSpellChecker поднимает XPC-процесс AppleSpell
+    /// (сотни мс на main) — без прогрева этот фриз пришёлся бы на первый пробел
+    /// пользователя после запуска. Вызывается отложенно из applicationDidFinishLaunching.
+    @MainActor static func warmUp() {
+        _ = languages()
+        _ = isValidWord("тест", lang: "ru")
+        _ = isValidWord("test", lang: "en")
     }
 
     /// true — слово есть в словаре языка (орфография корректна).

--- a/macos/Sources/RuSwitcher/LayoutSwitcher.swift
+++ b/macos/Sources/RuSwitcher/LayoutSwitcher.swift
@@ -3,6 +3,31 @@ import Foundation
 
 /// Управление раскладками через TIS API
 enum LayoutSwitcher {
+    /// Кэш списка раскладок: авто-путь дёргает TISCreateInputSourceList по 3–4 раза на
+    /// каждый пробел (convertKeys → currentAndOppositeLanguage → switchToOpposite), а
+    /// список меняется только при добавлении/удалении раскладки в системе. Инвалидация —
+    /// по распределённому уведомлению TIS (см. installObserverIfNeeded).
+    nonisolated(unsafe) private static var cachedLayouts: [TISInputSource]?
+    /// Кэш языка по sourceID: для сторонних раскладок languageCode гоняет UCKeyTranslate-пробы.
+    /// nil кодируем пустой строкой, чтобы не пере-пробовать безъязыкие раскладки.
+    nonisolated(unsafe) private static var languageCache: [String: String] = [:]
+    private static let cacheLock = NSLock()
+    nonisolated(unsafe) private static var observerInstalled = false
+
+    private static func installObserverIfNeeded() {
+        // Вызывается только под cacheLock (из installedLayouts) — гонки на флаге нет.
+        guard !observerInstalled else { return }
+        observerInstalled = true
+        let name = Notification.Name(kTISNotifyEnabledKeyboardInputSourcesChanged as String)
+        _ = DistributedNotificationCenter.default().addObserver(forName: name, object: nil, queue: nil) { _ in
+            cacheLock.lock()
+            cachedLayouts = nil
+            languageCache.removeAll()
+            cacheLock.unlock()
+            DynamicKeyMapping.clearCache()   // данные раскладки могли смениться вместе со списком
+        }
+    }
+
     /// Возвращает ID текущей раскладки
     static func currentLayoutID() -> String {
         guard let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else {
@@ -57,16 +82,22 @@ enum LayoutSwitcher {
         TISSelectInputSource(source)
     }
 
-    /// Все установленные раскладки
+    /// Все установленные раскладки (кэш; инвалидация по уведомлению TIS)
     static func installedLayouts() -> [TISInputSource] {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        installObserverIfNeeded()
+        if let cached = cachedLayouts { return cached }
+
         let conditions: CFDictionary = [
             kTISPropertyInputSourceCategory as String: kTISCategoryKeyboardInputSource as Any,
             kTISPropertyInputSourceIsSelectCapable as String: true as Any,
         ] as CFDictionary
 
         guard let list = TISCreateInputSourceList(conditions, false)?.takeRetainedValue() as? [TISInputSource] else {
-            return []
+            return []   // сбой не кэшируем — следующий вызов попробует снова
         }
+        cachedLayouts = list
         return list
     }
 
@@ -93,12 +124,27 @@ enum LayoutSwitcher {
     /// флаг/авто/каретка ломались (#18). Поэтому при пустых метаданных определяем язык по РЕАЛЬНОМУ
     /// выводу раскладки (UCKeyTranslate → скрипт → язык).
     static func languageCode(_ source: TISInputSource) -> String? {
+        let id = sourceID(source)
+        cacheLock.lock()
+        if let cached = languageCache[id] {
+            cacheLock.unlock()
+            return cached.isEmpty ? nil : cached
+        }
+        cacheLock.unlock()
+
+        let result: String?
         if let ptr = TISGetInputSourceProperty(source, kTISPropertyInputSourceLanguages),
            let langs = Unmanaged<CFArray>.fromOpaque(ptr).takeUnretainedValue() as? [String],
            let first = langs.first, !first.isEmpty {
-            return first                       // стандартная раскладка: конкретный язык из метаданных
+            result = first                     // стандартная раскладка: конкретный язык из метаданных
+        } else {
+            result = scriptLanguage(source)    // сторонняя: определяем по выводу
         }
-        return scriptLanguage(source)          // сторонняя: определяем по выводу
+
+        cacheLock.lock()
+        languageCache[id] = result ?? ""
+        cacheLock.unlock()
+        return result
     }
 
     /// Язык по СКРИПТУ реального вывода раскладки (для сторонних раскладок без метаданных).

--- a/macos/Sources/RuSwitcher/TextConverter.swift
+++ b/macos/Sources/RuSwitcher/TextConverter.swift
@@ -133,7 +133,7 @@ final class TextConverter {
         injectQueue.async { [weak self] in
             guard let self else { return }
             self.backspace(bsCount)
-            usleep(20_000)
+            usleep(8_000)   // короткий зазор стирание→вставка: порядок и так гарантирован очередью HID
             self.insertText(insert)
             Task { @MainActor in self.isConverting = false }
         }
@@ -178,7 +178,7 @@ final class TextConverter {
         injectQueue.async { [weak self] in
             guard let self else { return }
             self.backspace(bsCount)
-            usleep(20_000)
+            usleep(8_000)   // короткий зазор стирание→вставка: порядок и так гарантирован очередью HID
             self.insertText(converted)
             Task { @MainActor in self.isConverting = false }
         }
@@ -487,10 +487,13 @@ final class TextConverter {
     // MARK: - Private
 
     /// Стирает n символов (Backspace × n) — для движка перепечатки.
+    /// Пауза минимальная: порядок доставки гарантирует системная очередь HID, а при
+    /// прежних 3мс/клавишу стирание длинного слова растягивалось на кадры отрисовки —
+    /// пользователь видел «стёрли-и-перепечатали» вместо мгновенной замены.
     nonisolated private func backspace(_ n: Int) {
         for _ in 0..<n {
             simKey(keyCode: KC.backspace, flags: [])
-            usleep(3_000)
+            usleep(500)
         }
     }
 
@@ -598,7 +601,7 @@ final class TextConverter {
     nonisolated private func selectBack(_ count: Int) {
         for _ in 0..<count {
             simKey(keyCode: KC.left, flags: .maskShift)
-            usleep(3_000)
+            usleep(1_000)
         }
     }
 
@@ -606,7 +609,7 @@ final class TextConverter {
     nonisolated private func moveLeft(_ count: Int) {
         for _ in 0..<count {
             simKey(keyCode: KC.left, flags: [])
-            usleep(3_000)
+            usleep(1_000)
         }
     }
 
@@ -614,7 +617,7 @@ final class TextConverter {
     nonisolated private func moveRight(_ count: Int) {
         for _ in 0..<count {
             simKey(keyCode: KC.right, flags: [])
-            usleep(3_000)
+            usleep(1_000)
         }
     }
 

--- a/macos/Sources/RuSwitcher/TextConverter.swift
+++ b/macos/Sources/RuSwitcher/TextConverter.swift
@@ -48,6 +48,10 @@ final class TextConverter {
     private func isFocusedElementEditable() -> Bool {
         guard let app = NSWorkspace.shared.frontmostApplication else { return false }
         let axApp = AXUIElementCreateApplication(app.processIdentifier)
+        // Занятое приложение (Electron в GC, IDE в индексации) без таймаута держит main
+        // до 6с (дефолт AX) — это и есть «фризы». 0.2с хватает живому ответу; SpotlightAX
+        // такой же таймаут уже ставит.
+        AXUIElementSetMessagingTimeout(axApp, 0.2)
 
         var focusedRaw: AnyObject?
         let err = AXUIElementCopyAttributeValue(axApp, kAXFocusedUIElementAttribute as CFString, &focusedRaw)

--- a/macos/build_app.sh
+++ b/macos/build_app.sh
@@ -62,7 +62,8 @@ echo -n "APPL????" > "$APP_BUNDLE/Contents/PkgInfo"
 
 # 7. Подписываем Developer ID (разрешения macOS привязаны к подписи —
 #    при одинаковой подписи разрешения сохраняются между обновлениями)
-SIGN_ID="Developer ID Application: Rashid Nasibulin (9GEWCZ59HK)"
+# RS_SIGN_ID переопределяет identity (CI без сертификата ставит "-" — ad-hoc).
+SIGN_ID="${RS_SIGN_ID:-Developer ID Application: Rashid Nasibulin (9GEWCZ59HK)}"
 echo "→ Code signing with Developer ID..."
 codesign --force --deep --sign "$SIGN_ID" \
     --options runtime \


### PR DESCRIPTION
## Симптом

При обычной печати изредка «слегка фризит»: конверсия запаздывает, буфер слова разъезжается. Причина — event tap висит на main run loop (`KeyboardMonitor.swift`, `CFRunLoopGetMain`), и любой затык main голодит тап (вплоть до `tapDisabledByTimeout`, обработчик которого в коде уже есть).

## Коммит 1 — источники затыков main

- **`isFocusedElementEditable`: AX-таймаут 0.2с.** Сейчас запрос к фокусному приложению идёт с дефолтным таймаутом 6с — занятый Electron/IDE в индексации держит main до 6 секунд. В `SpotlightAX` вы такой же таймаут уже ставите — здесь он просто отсутствовал.
- **`LayoutSwitcher`: кэш `installedLayouts()`/`languageCode()`.** Авто-путь на каждом пробеле дёргает `TISCreateInputSourceList` 3–4 раза (convertKeys → currentAndOppositeLanguage → switchToOpposite), а для сторонних раскладок ещё и UCKeyTranslate-пробы языка. Список меняется только при добавлении/удалении раскладки — инвалидация по `kTISNotifyEnabledKeyboardInputSourcesChanged` (+ сброс кэша DynamicKeyMapping). Доступ под NSLock.
- **`Dict`: кэш `availableLanguages` + прогрев.** Первое обращение к NSSpellChecker поднимает XPC-процесс AppleSpell (сотни мс) — раньше это приходилось ровно на первый пробел пользователя. Прогрев уходит в тихую паузу через 2с после старта. Оговорка: словарь, доустановленный в систему посреди сессии, увидится после перезапуска — счёл приемлемым.
- **`build_app.sh`: `RS_SIGN_ID`** — переопределение подписи, чтобы форки/CI могли собирать ad-hoc без вашего сертификата. Дефолт не тронут.

## Коммит 2 — «стёрли и заново напечатали»

Паузы инжекта перепечатки (3мс/Backspace + 20мс перед вставкой) размазывали замену 8-буквенного слова на ~45мс — несколько кадров отрисовки, глаз видит стирание и перепечатку, читается как тормоза. Порядок доставки гарантирует системная очередь HID, поэтому паузы ужаты (0.5мс / 8мс / стрелки 1мс): замена умещается в ~12мс — один кадр, визуально мгновенная. Этот коммит обкатан на одной машине (см. ниже) — если у вас были прецеденты, где 20мс спасали медленные приложения, скажите, вынесу в константу/настройку.

## Тестирование

Живьём на macOS 13.6 (Intel): автоконвертация и ручной триггер в WebStorm (JediTerm), Chrome, нативных полях — по debug-логу вердикты корректные, конверсия работает, фризы ушли, замена слова визуально мгновенная. Swift 6, собирается вашим `build_app.sh` без изменений поведения при наличии сертификата.

🤖 Generated with [Claude Code](https://claude.com/claude-code)